### PR TITLE
Update getTypeProp to work with Object.defineProperties

### DIFF
--- a/generateSchema.js
+++ b/generateSchema.js
@@ -73,7 +73,9 @@ function getTypeProp(source, typeProp) {
 // Yes, we really are going to parse an entire JS file using Esprima, and navigate all the way down the hierarchy just to identify the magic
 // statement that looks like `return 'geojson';`
     try {
-        var r = source.body.filter(eq('expression.callee.name', 'defineProperties'))[0] // inside a defineProperties block
+        var r = source.body.filter(
+            eq('expression.callee.object.name', 'Object') && 
+            eq('expression.callee.property.name', 'defineProperties'))[0] // inside an Object.defineProperties block
             .expression.arguments[1].properties.filter(eq('key.name', typeProp))[0]     // a property of the form '<typeProp>: { ... }'
             .value.properties[0].value.body.body[0].argument.value;                     // ........... return 'thebitwewant';
         return r;


### PR DESCRIPTION
Cesium has removed their implementation of `defineProperties` and started using `Object.defineProperties` instead. This change ended up giving errors because when generating schema we specifically look for the `defineProperties` block. I've modified it so that now we look for `Object.defineProperties` block instead